### PR TITLE
enable get_sysvar_syscall feature flag

### DIFF
--- a/src/trident_svm.rs
+++ b/src/trident_svm.rs
@@ -85,6 +85,7 @@ impl Default for TridentSVM {
             enable_sbpf_v1_deployment_and_execution: true,
             enable_sbpf_v2_deployment_and_execution: true,
             enable_sbpf_v3_deployment_and_execution: true,
+            get_sysvar_syscall_enabled: true,
             ..Default::default()
         };
 


### PR DESCRIPTION
This is necessary to allow fuzzing of programs built using latest versions of Pinocchio (and perhaps other libraries).

[PR](https://github.com/Ackee-Blockchain/trident-syscall-stubs/pull/3) for adding the required syscall stub

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default Solana SVM feature configuration, which can affect program execution behavior in tests/fuzzing environments. Scope is small (single flag) but touches core runtime feature gating.
> 
> **Overview**
> Enables the `get_sysvar` syscall by default in `TridentSVM` via `SVMFeatureSet::get_sysvar_syscall_enabled`, improving compatibility with programs built against newer libraries (e.g., Pinocchio) during local execution/fuzzing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 297b5acf23cf371046ded1ad39f03a21c7c12a30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->